### PR TITLE
Fix broken link in narrative 2020-03-04

### DIFF
--- a/ncov_sit-rep_2020-03-04.md
+++ b/ncov_sit-rep_2020-03-04.md
@@ -110,7 +110,7 @@ In an effort to try and explain why these views are incorrect, scientists have a
 # [Phylogenetic analysis](https://nextstrain.org/ncov/2020-03-04?d=tree)
 
 Here we present a phylogeny of 161</tag> strains of SARS-CoV-2 (the virus that causes COVID-19) that have been publicly shared.
-Information on how the analysis was performed is available [in this GitHub repository](github.com/nextstrain/ncov).
+Information on how the analysis was performed is available [in this GitHub repository](https://github.com/nextstrain/ncov).
 
 <br>
 


### PR DESCRIPTION
Previous relative link format would link to https://nextstrain.org/narratives/ncov/sit-rep/github.com/nextstrain/ncov. This changes the link to an absolute URL with HTTPS protocol prefix.