### PR TITLE
Fix noun that should be verb

### DIFF
--- a/ncov_sit-rep_2020-05-15.md
+++ b/ncov_sit-rep_2020-05-15.md
@@ -54,7 +54,7 @@ We analyzed 5,193 publicly shared COVID-19 genomes. By comparing these viral gen
 * [Common misconceptions](https://nextstrain.org/narratives/ncov/sit-rep/2020-03-13?n=11).
 
 #### External Resources
-* [How coronavirus mutations and spreads (NYTimes)](https://www.nytimes.com/interactive/2020/04/30/science/coronavirus-mutations.html).
+* [How coronavirus mutates and spreads (NYTimes)](https://www.nytimes.com/interactive/2020/04/30/science/coronavirus-mutations.html).
 * [Ask a Scientist & FAQs](https://covid19.fas.org/l/en).
 * [WHO Situation Reports](https://www.who.int/emergencies/diseases/novel-coronavirus-2019/situation-reports).
 * [CDC Resources](https://www.cdc.gov/coronavirus/2019-ncov/index.html).


### PR DESCRIPTION
### Description of proposed changes    
Changed the grammatically incorrect sentence "How coronavirus mutations and spreads" into "How coronavirus mutates and spreads".
